### PR TITLE
Fix can not sync forked block issue

### DIFF
--- a/sdk/spvclientimpl.go
+++ b/sdk/spvclientimpl.go
@@ -107,7 +107,6 @@ func (client *SPVClientImpl) OnPeerEstablish(peer *net.Peer) {
 }
 
 func (client *SPVClientImpl) OnPing(peer *net.Peer, p *msg.Ping) error {
-	log.Debug()
 	peer.SetHeight(p.Nonce)
 	// Return pong message to peer
 	peer.Send(msg.NewPong(uint32(client.PeerManager().Local().Height())))
@@ -115,7 +114,6 @@ func (client *SPVClientImpl) OnPing(peer *net.Peer, p *msg.Ping) error {
 }
 
 func (client *SPVClientImpl) OnPong(peer *net.Peer, p *msg.Pong) error {
-	log.Debug()
 	peer.SetHeight(p.Nonce)
 	return nil
 }


### PR DESCRIPTION
Figure out that the block commit queue will prevent forked block from commit into database. Separate block downloading and storing is for better performance on syncing blocks, but this asynchronous design makes new problems. So for stabilize the syncing progress, we remove commit queue to make block download and commit in synchronous. 