### PR TITLE
Fix SPV reconnection not working issue

### DIFF
--- a/interface/p2pclientimpl.go
+++ b/interface/p2pclientimpl.go
@@ -28,7 +28,7 @@ func (c *P2PClientImpl) InitLocalPeer(initLocal func(peer *net.Peer)) {
 	// Create peer manager of the P2P network
 	local := new(net.Peer)
 	initLocal(local)
-	c.pm = net.InitPeerManager(c.magic, c.maxMsgSize, c.seeds, c.minOutbound, c.maxConnections, local)
+	c.pm = net.NewPeerManager(c.magic, c.maxMsgSize, c.seeds, c.minOutbound, c.maxConnections, local)
 }
 
 func (c *P2PClientImpl) SetMessageHandler(msgHandler net.MessageHandler) {

--- a/net/addrmanager.go
+++ b/net/addrmanager.go
@@ -43,7 +43,7 @@ func (am *AddrManager) GetOutboundAddresses(cm *ConnManager) []p2p.NetAddress {
 	for _, addr := range SortAddressMap(am.addrList) {
 		address := addr.String()
 		// Skip connecting address
-		if cm.isConnecting(address) {
+		if cm.IsConnecting(address) {
 			continue
 		}
 		// Skip connected address

--- a/net/peermanager.go
+++ b/net/peermanager.go
@@ -4,13 +4,13 @@ import (
 	"errors"
 	"net"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/elastos/Elastos.ELA.SPV/log"
 
 	"github.com/elastos/Elastos.ELA.Utility/p2p"
 	"github.com/elastos/Elastos.ELA.Utility/p2p/msg"
-	"sync"
 )
 
 const (
@@ -47,7 +47,7 @@ type PeerManager struct {
 	cm *ConnManager
 }
 
-func InitPeerManager(magic, maxMsgSize uint32, seeds []string, minOutbound, maxConnections int, localPeer *Peer) *PeerManager {
+func NewPeerManager(magic, maxMsgSize uint32, seeds []string, minOutbound, maxConnections int, localPeer *Peer) *PeerManager {
 	// Initiate PeerManager
 	pm := new(PeerManager)
 	pm.magic = magic
@@ -142,7 +142,7 @@ func (pm *PeerManager) connectPeers() {
 	// connect seeds first
 	if pm.PeersCount() < MinConnections {
 		for _, addr := range pm.seeds {
-			if pm.cm.isConnected(addr) {
+			if pm.cm.IsConnected(addr) {
 				continue
 			}
 			go pm.cm.Connect(addr)

--- a/net/peermanager_test.go
+++ b/net/peermanager_test.go
@@ -1,0 +1,59 @@
+package net
+
+import (
+	"math/rand"
+	"net"
+	"testing"
+
+	"github.com/elastos/Elastos.ELA.SPV/log"
+
+	"github.com/elastos/Elastos.ELA.Utility/p2p"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPeerManager_AddConnectedPeer(t *testing.T) {
+	log.Init(0, 5, 10)
+	pm := NewPeerManager(123456, 1024, nil, 4, 100, nil)
+	addPeer := func() {
+	ADD:
+		peer := new(Peer)
+		peer.conn = new(net.TCPConn)
+		peer.id = rand.Uint64()
+		peer.height = rand.Uint64()
+		peer.SetState(p2p.ESTABLISH)
+		rand.Read(peer.ip16[:])
+		peer.port = uint16(rand.Uint32())
+		pm.AddConnectedPeer(peer)
+		assert.Equal(t, true, pm.cm.IsConnected(peer.Addr().String()))
+		if pm.PeersCount() < 10 {
+			goto ADD
+		}
+	}
+
+	done := make(chan struct{})
+
+	go func() {
+		for {
+			addPeer()
+		}
+	}()
+
+	go func() {
+		count := 0
+		for {
+		NEXT:
+			peer := pm.GetSyncPeer()
+			if peer == nil {
+				goto NEXT
+			}
+			pm.OnDisconnected(peer)
+			assert.Equal(t, false, pm.cm.IsConnected(peer.Addr().String()))
+			count++
+			if count > 100 {
+				done <- struct{}{}
+			}
+		}
+	}()
+
+	<-done
+}

--- a/sdk/p2pclientimpl.go
+++ b/sdk/p2pclientimpl.go
@@ -28,7 +28,7 @@ func NewP2PClientImpl(magic, maxMsgSize uint32, clientId uint64, seeds []string,
 	client := new(P2PClientImpl)
 
 	// Initialize peer manager
-	client.peerManager = net.InitPeerManager(magic, maxMsgSize, seeds, minOutbound, maxConnections, local)
+	client.peerManager = net.NewPeerManager(magic, maxMsgSize, seeds, minOutbound, maxConnections, local)
 
 	return client, nil
 }


### PR DESCRIPTION
Some times, SPV stops syncing data at some point. This always happens when a new block was mined and cause a disconnection. It figured out the disconnected peer still in connected peers list. That makes reconnection not working because connected peers will be skipped from reconnect. So add a mutex lock when peer manager add a new connected peer or delete a disconnected peer.