### PR TITLE
Bug fix and refactor

### DIFF
--- a/interface/p2pclient.go
+++ b/interface/p2pclient.go
@@ -13,7 +13,7 @@ type P2PClient interface {
 	InitLocalPeer(func(*net.Peer))
 
 	// Set the message handler
-	SetMessageHandler(handler net.MessageHandler)
+	SetMessageHandler(handler func() net.MessageHandler)
 
 	// Start the P2P client
 	Start()

--- a/interface/p2pclientimpl.go
+++ b/interface/p2pclientimpl.go
@@ -31,8 +31,8 @@ func (c *P2PClientImpl) InitLocalPeer(initLocal func(peer *net.Peer)) {
 	c.pm = net.NewPeerManager(c.magic, c.maxMsgSize, c.seeds, c.minOutbound, c.maxConnections, local)
 }
 
-func (c *P2PClientImpl) SetMessageHandler(msgHandler net.MessageHandler) {
-	c.pm.SetMessageHandler(msgHandler)
+func (c *P2PClientImpl) SetMessageHandler(messageHandler func() net.MessageHandler) {
+	c.pm.SetMessageHandler(messageHandler)
 }
 
 func (c *P2PClientImpl) Start() {

--- a/interface/spvservice_test.go
+++ b/interface/spvservice_test.go
@@ -96,7 +96,7 @@ func TestGetListenerKey(t *testing.T) {
 }
 
 func TestNewSPVService(t *testing.T) {
-	log.Init(log.LevelDebug)
+	log.Init(0, 5, 20)
 
 	var id = make([]byte, 8)
 	var clientId uint64

--- a/net/connmanager.go
+++ b/net/connmanager.go
@@ -14,20 +14,20 @@ const (
 	HandshakeTimeout = 3
 )
 
+type connMsg struct {
+	inbound  bool
+	conn     net.Conn
+}
+
 type ConnectionListener interface {
-	OnOutbound(conn net.Conn)
-	OnInbound(conn net.Conn)
+	OnConnection(msg connMsg)
 }
 
 type ConnManager struct {
 	localPeer      *Peer
 	maxConnections int
 
-	connectingLock *sync.RWMutex
-	connectingList map[string]string
-
-	connsLock   *sync.RWMutex
-	handshakes  map[net.Conn]struct{}
+	mutex       *sync.RWMutex
 	connections map[string]net.Conn
 
 	listener ConnectionListener
@@ -37,27 +37,25 @@ func newConnManager(localPeer *Peer, maxConnections int, listener ConnectionList
 	cm := new(ConnManager)
 	cm.localPeer = localPeer
 	cm.maxConnections = maxConnections
-	cm.connectingLock = new(sync.RWMutex)
-	cm.connectingList = make(map[string]string)
-	cm.connsLock = new(sync.RWMutex)
-	cm.handshakes = make(map[net.Conn]struct{})
+	cm.mutex = new(sync.RWMutex)
 	cm.connections = make(map[string]net.Conn)
 	cm.listener = listener
 	return cm
 }
 
-func (cm *ConnManager) Connect(addr string) {
-	cm.connectingLock.Lock()
-	defer cm.connectingLock.Unlock()
-
-	if _, ok := cm.connectingList[addr]; ok {
-		return
+func (cm *ConnManager) ResolveAddr(addr string) (string, error) {
+	tcpAddr, err := net.ResolveTCPAddr("tcp", addr)
+	if err != nil {
+		log.Debugf("Can not resolve address %s", addr)
+		return addr, err
 	}
-	// add to connecting list
-	cm.connectingList[addr] = addr
 
-	// de connecting address after connection created or failed
-	defer delete(cm.connectingList, addr)
+	log.Debugf("Seed %s, resolved addr %s", addr, tcpAddr.String())
+	return tcpAddr.String(), nil
+}
+
+func (cm *ConnManager) Connect(addr string) {
+	log.Debugf("Connect addr %s", addr)
 
 	conn, err := net.DialTimeout("tcp", addr, time.Second*ConnTimeOut)
 	if err != nil {
@@ -65,61 +63,29 @@ func (cm *ConnManager) Connect(addr string) {
 		return
 	}
 
-	// Start handshake
-	cm.StartHandshake(conn)
-	// Callback connection
-	cm.listener.OnOutbound(conn)
-}
-
-func (cm *ConnManager) IsConnecting(addr string) bool {
-	cm.connectingLock.RLock()
-	defer cm.connectingLock.RUnlock()
-	_, ok := cm.connectingList[addr]
-	return ok
+	// Callback outbound connection
+	cm.listener.OnConnection(connMsg{inbound: false, conn: conn})
 }
 
 func (cm *ConnManager) IsConnected(addr string) bool {
-	cm.connsLock.RLock()
-	defer cm.connsLock.RUnlock()
+	cm.mutex.RLock()
+	defer cm.mutex.RUnlock()
 	_, ok := cm.connections[addr]
 	return ok
 }
 
-func (cm *ConnManager) StartHandshake(conn net.Conn) {
-	cm.connsLock.Lock()
-	defer cm.connsLock.Unlock()
-	// Put into handshakes
-	cm.handshakes[conn] = struct{}{}
-
-	// Close handshake timeout connections
-	go cm.handleTimeout(conn)
-}
-
-func (cm *ConnManager) handleTimeout(conn net.Conn) {
-	time.Sleep(time.Second * HandshakeTimeout)
-	cm.connsLock.Lock()
-	if _, ok := cm.handshakes[conn]; ok {
-		conn.Close()
-		delete(cm.handshakes, conn)
-	}
-	cm.connsLock.Unlock()
-}
-
 func (cm *ConnManager) PeerConnected(addr string, conn net.Conn) {
-	cm.connsLock.Lock()
-	defer cm.connsLock.Unlock()
-	// Remove from handshakes
-	delete(cm.handshakes, conn)
+	cm.mutex.Lock()
+	defer cm.mutex.Unlock()
 	// Add to connection list
 	cm.connections[addr] = conn
 }
 
 func (cm *ConnManager) PeerDisconnected(addr string) {
-	cm.connsLock.Lock()
-	defer cm.connsLock.Unlock()
+	cm.mutex.Lock()
+	defer cm.mutex.Unlock()
 
-	if conn, ok := cm.connections[addr]; ok {
-		conn.Close()
+	if _, ok := cm.connections[addr]; ok {
 		delete(cm.connections, addr)
 	}
 }
@@ -140,15 +106,15 @@ func (cm *ConnManager) listenConnection() {
 		}
 		log.Debugf("New connection accepted, remote: %s local: %s\n", conn.RemoteAddr(), conn.LocalAddr())
 
-		cm.StartHandshake(conn)
-		cm.listener.OnInbound(conn)
+		// Callback inbound connection
+		cm.listener.OnConnection(connMsg{inbound: true, conn: conn})
 	}
 }
 
 func (cm *ConnManager) monitorConnections() {
 	ticker := time.NewTicker(time.Second * InfoUpdateDuration)
 	for range ticker.C {
-		cm.connsLock.Lock()
+		cm.mutex.Lock()
 		conns := len(cm.connections)
 		if conns > cm.maxConnections {
 			// Random close connections
@@ -160,6 +126,6 @@ func (cm *ConnManager) monitorConnections() {
 				}
 			}
 		}
-		cm.connsLock.Unlock()
+		cm.mutex.Unlock()
 	}
 }

--- a/net/peer.go
+++ b/net/peer.go
@@ -12,7 +12,8 @@ import (
 )
 
 type PeerHandler interface {
-	MessageHandler
+	MakeMessage(cmd string) (p2p.Message, error)
+	HandleMessage(peer *Peer, msg p2p.Message) error
 	OnDisconnected(peer *Peer)
 }
 

--- a/net/peer.go
+++ b/net/peer.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"net"
 	"time"
+	"sync/atomic"
+	"strings"
 
 	"github.com/elastos/Elastos.ELA.SPV/log"
 
@@ -11,10 +13,10 @@ import (
 	"github.com/elastos/Elastos.ELA.Utility/p2p/msg"
 )
 
-type PeerHandler interface {
-	MakeMessage(cmd string) (p2p.Message, error)
-	HandleMessage(peer *Peer, msg p2p.Message) error
-	OnDisconnected(peer *Peer)
+type PeerHandler struct {
+	OnDisconnected func(peer *Peer)
+	MakeMessage    func(cmd string) (p2p.Message, error)
+	HandleMessage  func(peer *Peer, msg p2p.Message) error
 }
 
 type Peer struct {
@@ -27,149 +29,185 @@ type Peer struct {
 	height     uint64
 	relay      uint8 // 1 for true 0 for false
 
-	p2p.PeerState
+	state   int32
 	conn    net.Conn
 	handler PeerHandler
 
 	msgHelper *p2p.MsgHelper
 }
 
-func (peer *Peer) String() string {
+func (p *Peer) String() string {
+	var state p2p.PeerState
+	state.SetState(uint(p.state))
 	return fmt.Sprint(
-		"ID:", peer.id,
-		", Version:", peer.version,
-		", Services:", peer.services,
-		", Port:", peer.port,
-		", LastActive:", peer.lastActive,
-		", Height:", peer.height,
-		", Relay:", peer.relay,
-		", State:", peer.PeerState.String(),
-		", Addr:", peer.Addr().String())
+		"ID:", p.id,
+		", Version:", p.version,
+		", Services:", p.services,
+		", Port:", p.port,
+		", LastActive:", p.lastActive,
+		", Height:", p.height,
+		", Relay:", p.relay,
+		", State:", state.String(),
+		", Addr:", p.Addr().String())
 }
 
-func (peer *Peer) ID() uint64 {
-	return peer.id
+func (p *Peer) ID() uint64 {
+	return p.id
 }
 
-func (peer *Peer) SetID(id uint64) {
-	peer.id = id
+func (p *Peer) SetID(id uint64) {
+	p.id = id
 }
 
-func (peer *Peer) Version() uint32 {
-	return peer.version
+func (p *Peer) Version() uint32 {
+	return p.version
 }
 
-func (peer *Peer) SetVersion(version uint32) {
-	peer.version = version
+func (p *Peer) SetVersion(version uint32) {
+	p.version = version
 }
 
-func (peer *Peer) Services() uint64 {
-	return peer.services
+func (p *Peer) Services() uint64 {
+	return p.services
 }
 
-func (peer *Peer) SetServices(servcies uint64) {
-	peer.services = servcies
+func (p *Peer) SetServices(services uint64) {
+	p.services = services
 }
 
-func (peer *Peer) IP16() [16]byte {
-	return peer.ip16
+func (p *Peer) IP16() [16]byte {
+	return p.ip16
 }
 
-func (peer *Peer) Port() uint16 {
-	return peer.port
+func (p *Peer) Port() uint16 {
+	return p.port
 }
 
-func (peer *Peer) SetPort(port uint16) {
-	peer.port = port
+func (p *Peer) SetPort(port uint16) {
+	p.port = port
 }
 
-func (peer *Peer) LastActive() time.Time {
-	return peer.lastActive
+func (p *Peer) LastActive() time.Time {
+	return p.lastActive
 }
 
-func (peer *Peer) Addr() *p2p.NetAddress {
-	return p2p.NewNetAddress(peer.services, peer.ip16, peer.port, peer.id)
+func (p *Peer) Addr() *p2p.NetAddress {
+	return p2p.NewNetAddress(p.services, p.ip16, p.port, p.id)
 }
 
-func (peer *Peer) Relay() uint8 {
-	return peer.relay
+func (p *Peer) Relay() uint8 {
+	return p.relay
 }
 
-func (peer *Peer) SetRelay(relay uint8) {
-	peer.relay = relay
+func (p *Peer) SetRelay(relay uint8) {
+	p.relay = relay
 }
 
-func (peer *Peer) Disconnect() {
-	if peer.State() != p2p.INACTIVITY {
-		peer.SetState(p2p.INACTIVITY)
-		peer.conn.Close()
+func (p *Peer) State() int32 {
+	return atomic.LoadInt32(&p.state)
+}
+
+func (p *Peer) SetState(state int32) {
+	atomic.StoreInt32(&p.state, state)
+}
+
+func (p *Peer) Disconnect() {
+	// Return if peer already disconnected
+	if p.State() == p2p.INACTIVITY {
+		return
 	}
+	p.SetState(p2p.INACTIVITY)
+	p.conn.Close()
 }
 
-func (peer *Peer) SetInfo(msg *msg.Version) {
-	peer.id = msg.Nonce
-	peer.port = msg.Port
-	peer.version = msg.Version
-	peer.services = msg.Services
-	peer.lastActive = time.Now()
-	peer.height = msg.Height
-	peer.relay = msg.Relay
+func (p *Peer) SetInfo(msg *msg.Version) {
+	p.id = msg.Nonce
+	p.port = msg.Port
+	p.version = msg.Version
+	p.services = msg.Services
+	p.lastActive = time.Now()
+	p.height = msg.Height
+	p.relay = msg.Relay
 }
 
-func (peer *Peer) SetHeight(height uint64) {
-	peer.height = height
+func (p *Peer) SetHeight(height uint64) {
+	p.height = height
 }
 
-func (peer *Peer) Height() uint64 {
-	return peer.height
+func (p *Peer) Height() uint64 {
+	return p.height
 }
 
-func (peer *Peer) OnError(err error) {
+func (p *Peer) OnError(err error) {
 	switch err {
 	case p2p.ErrInvalidHeader,
 		p2p.ErrUnmatchedMagic,
 		p2p.ErrMsgSizeExceeded:
 		log.Error(err)
-		peer.Disconnect()
+		p.Disconnect()
 	case p2p.ErrDisconnected:
-		peer.handler.OnDisconnected(peer)
+		p.handler.OnDisconnected(p)
 	default:
-		log.Error(err, ", peer id is: ", peer.ID())
+		log.Error(err, ", peer id is: ", p.ID())
 	}
 }
 
-func (peer *Peer) OnMakeMessage(cmd string) (p2p.Message, error) {
-	peer.lastActive = time.Now()
-	return peer.handler.MakeMessage(cmd)
+func (p *Peer) OnMakeMessage(cmd string) (p2p.Message, error) {
+	if p.State() == p2p.INACTIVITY {
+		return nil, fmt.Errorf("-----> [%s] from INACTIVE peer [%d]", cmd, p.id)
+	}
+	p.lastActive = time.Now()
+	return p.handler.MakeMessage(cmd)
 }
 
-func (peer *Peer) OnMessageDecoded(msg p2p.Message) {
-	if err := peer.handler.HandleMessage(peer, msg); err != nil {
+func (p *Peer) OnMessageDecoded(message p2p.Message) {
+	log.Debugf("-----> [%s] from peer [%d] STARTED", message.CMD(), p.id)
+	if err := p.handler.HandleMessage(p, message); err != nil {
 		log.Error(err)
 	}
+	log.Debugf("-----> [%s] from peer [%d] FINISHED", message.CMD(), p.id)
 }
 
-func (peer *Peer) Read() {
-	peer.msgHelper.Read()
+func (p *Peer) Start() {
+	p.msgHelper.Read()
 }
 
-func (peer *Peer) Send(msg p2p.Message) {
-	if peer.State() == p2p.INACTIVITY {
+func (p *Peer) Send(msg p2p.Message) {
+	if p.State() == p2p.INACTIVITY {
+		log.Errorf("-----> Push [%s] to INACTIVE peer [%d]", msg.CMD(), p.id)
 		return
 	}
-
-	peer.msgHelper.Write(msg)
-	peer.lastActive = time.Now()
+	log.Debugf("-----> Push [%s] to peer [%d] STARTED", msg.CMD(), p.id)
+	p.msgHelper.Write(msg)
+	log.Debugf("-----> Push [%s] to peer [%d] FINISHED", msg.CMD(), p.id)
 }
 
-func (peer *Peer) NewVersionMsg() *msg.Version {
+func (p *Peer) NewVersionMsg() *msg.Version {
 	version := new(msg.Version)
-	version.Version = peer.Version()
-	version.Services = peer.Services()
+	version.Version = p.Version()
+	version.Services = p.Services()
 	version.TimeStamp = uint32(time.Now().UnixNano())
-	version.Port = peer.Port()
-	version.Nonce = peer.ID()
-	version.Height = peer.Height()
-	version.Relay = peer.Relay()
+	version.Port = p.Port()
+	version.Nonce = p.ID()
+	version.Height = p.Height()
+	version.Relay = p.Relay()
 	return version
+}
+
+func (p *Peer) SetPeerHandler(handler PeerHandler) {
+	p.handler = handler
+}
+
+func NewPeer(magic, maxMsgSize uint32, conn net.Conn) *Peer {
+	peer := new(Peer)
+	peer.conn = conn
+	copy(peer.ip16[:], getIp(conn))
+	peer.msgHelper = p2p.NewMsgHelper(magic, maxMsgSize, conn, peer)
+	return peer
+}
+
+func getIp(conn net.Conn) []byte {
+	addr := conn.RemoteAddr().String()
+	portIndex := strings.LastIndex(addr, ":")
+	return net.ParseIP(string([]byte(addr)[:portIndex])).To16()
 }

--- a/net/peermanager_test.go
+++ b/net/peermanager_test.go
@@ -23,7 +23,7 @@ func TestPeerManager_AddConnectedPeer(t *testing.T) {
 		peer.SetState(p2p.ESTABLISH)
 		rand.Read(peer.ip16[:])
 		peer.port = uint16(rand.Uint32())
-		pm.AddConnectedPeer(peer)
+		pm.PeerConnected(peer)
 		assert.Equal(t, true, pm.cm.IsConnected(peer.Addr().String()))
 		if pm.PeersCount() < 10 {
 			goto ADD
@@ -46,7 +46,7 @@ func TestPeerManager_AddConnectedPeer(t *testing.T) {
 			if peer == nil {
 				goto NEXT
 			}
-			pm.OnDisconnected(peer)
+			pm.PeerDisconnected(peer)
 			assert.Equal(t, false, pm.cm.IsConnected(peer.Addr().String()))
 			count++
 			if count > 100 {

--- a/sdk/spvclient.go
+++ b/sdk/spvclient.go
@@ -14,7 +14,7 @@ you can see how to extend the SDK and create your own apps.
 */
 type SPVClient interface {
 	// Set the message handler to extend the client
-	SetMessageHandler(SPVMessageHandler)
+	SetMessageHandler(func() SPVMessageHandler)
 
 	// Start the client
 	Start()

--- a/sdk/spvclientimpl.go
+++ b/sdk/spvclientimpl.go
@@ -131,22 +131,19 @@ func (h *spvHandler) OnPong(peer *net.Peer, p *msg.Pong) error {
 func (h *spvHandler) heartBeat(peer *net.Peer) {
 	ticker := time.NewTicker(time.Second * net.InfoUpdateDuration)
 	defer ticker.Stop()
-	for range ticker.C {
-		// Quit if peer disconnected
-		if !h.peerManager.Exist(peer) {
-			goto QUIT
-		}
+	for {
+		select {
+		case <-ticker.C:
+			// Disconnect peer if keep alive timeout
+			if time.Now().After(peer.LastActive().Add(time.Second * net.InfoUpdateDuration * net.KeepAliveTimeout)) {
+				peer.Disconnect()
+				return
+			}
 
-		// Disconnect peer if keep alive timeout
-		if time.Now().After(peer.LastActive().Add(time.Second * net.InfoUpdateDuration * net.KeepAliveTimeout)) {
-			peer.Disconnect()
-			goto QUIT
-		}
-
-		// Send ping message to peer
-		if peer.State() == p2p.ESTABLISH {
-			go peer.Send(msg.NewPing(uint32(h.peerManager.Local().Height())))
+			// Send ping message to peer
+			if peer.State() == p2p.ESTABLISH {
+				peer.Send(msg.NewPing(uint32(h.peerManager.Local().Height())))
+			}
 		}
 	}
-QUIT:
 }

--- a/sdk/spvserviceimpl.go
+++ b/sdk/spvserviceimpl.go
@@ -262,8 +262,8 @@ func (s *SPVServiceImpl) stopSyncing() {
 	}
 	// Set blockchain state to waiting
 	s.chain.SetChainState(WAITING)
-	// Remove sync peer
-	s.PeerManager().SetSyncPeer(nil)
+	// Clear sync peer
+	s.PeerManager().ClearSyncPeer()
 	// Update bloom filter
 	s.ReloadFilter()
 }


### PR DESCRIPTION
1. Fix addresses reconnection not working issue.
If an address was dialed with error, this address should remove from connecting list, but it didn't. So use `defer delete(cm.connectingList, addr)` to make sure the dialed address will remove from connection list whether dial succeed or not.

2.  Refactor message handlers to make each peer has it's own message handler.
When all peers are using the same message handler, the message will be disordered. For data transfer protocol need messages are ordered, like A said "foo" to B, B must say "bar" to A, but A got "foo" from C. The disordered messages will make data transfer not work properly. So we allocate a new message handler instance for each peer, like A speak to B in a private channel, this makes A can only receive B's message or speak to B in this channel. So the messages between A and B can be ordered, and makes data transfer protocol work properly.

3. Implement sync handler to handler block syncing progress.
Sync handler is a loop to monitor block syncing progress, handle pending messages and stall timeout. Any peer got stalled or misbehaving will be disconnected. This is to prevent local peer stalled in syncing progress.