### PR TITLE
Send bloom filter for all candidate peers

### DIFF
--- a/interface/spvservice.go
+++ b/interface/spvservice.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/elastos/Elastos.ELA/common"
 	"github.com/elastos/Elastos.ELA/core/types"
+	"github.com/elastos/Elastos.ELA/elanet/pact"
 	"github.com/elastos/Elastos.ELA/p2p/msg"
 )
 
@@ -79,11 +80,15 @@ func newSpvService(cfg *Config) (*spvservice, error) {
 	chainStore := database.NewChainDB(headerStore, service)
 
 	serviceCfg := &sdk.Config{
-		DataDir:        dataDir,
-		Magic:          cfg.Magic,
-		SeedList:       cfg.SeedList,
-		DefaultPort:    cfg.DefaultPort,
-		MaxPeers:       cfg.MaxConnections,
+		DataDir:     dataDir,
+		Magic:       cfg.Magic,
+		SeedList:    cfg.SeedList,
+		DefaultPort: cfg.DefaultPort,
+		MaxPeers:    cfg.MaxConnections,
+		CandidateFlags: []uint64{
+			uint64(pact.SFNodeNetwork),
+			uint64(pact.SFNodeBloom),
+		},
 		GenesisHeader:  GenesisHeader(foundation),
 		ChainStore:     chainStore,
 		NewTransaction: newTransaction,

--- a/sdk/interface.go
+++ b/sdk/interface.go
@@ -70,6 +70,9 @@ type Config struct {
 	// The max peer connections.
 	MaxPeers int
 
+	// CandidateFlags defines flags needed for a sync candidate.
+	CandidateFlags []uint64
+
 	// GenesisHeader is the
 	GenesisHeader util.BlockHeader
 

--- a/sdk/service.go
+++ b/sdk/service.go
@@ -82,7 +82,8 @@ func newService(cfg *Config) (*service, error) {
 	}
 
 	// Create sync manager instance.
-	syncCfg := sync.NewDefaultConfig(chain, service.updateFilter)
+	syncCfg := sync.NewDefaultConfig(chain, cfg.CandidateFlags,
+		service.updateFilter)
 	syncCfg.MaxPeers = maxPeers
 	if cfg.StateNotifier != nil {
 		syncCfg.TransactionAnnounce = cfg.StateNotifier.TransactionAnnounce

--- a/sync/config.go
+++ b/sync/config.go
@@ -12,19 +12,20 @@ const (
 
 // Config is a configuration struct used to initialize a new SyncManager.
 type Config struct {
-	Chain *blockchain.BlockChain
-
-	MaxPeers int
+	Chain          *blockchain.BlockChain
+	MaxPeers       int
+	CandidateFlags []uint64
 
 	UpdateFilter        func() *bloom.Filter
 	TransactionAnnounce func(tx util.Transaction)
 }
 
-func NewDefaultConfig(chain *blockchain.BlockChain,
+func NewDefaultConfig(chain *blockchain.BlockChain, candidateFlags []uint64,
 	updateFilter func() *bloom.Filter) *Config {
 	return &Config{
-		Chain:        chain,
-		MaxPeers:     defaultMaxPeers,
-		UpdateFilter: updateFilter,
+		Chain:          chain,
+		CandidateFlags: candidateFlags,
+		MaxPeers:       defaultMaxPeers,
+		UpdateFilter:   updateFilter,
 	}
 }


### PR DESCRIPTION
Note: this PR should after https://github.com/elastos/Elastos.ELA/pull/674 has been merged.

Sometimes SPV become not synchronizing blocks.  That happens when connected peers do not send blocks to the SPV client.

One of the situation is SPV not sending FilterLoad message to the connected peers except the sync peer, if the sync peer not working, the SPV become not synchronizing blocks.

So it is necessary to send FilterLoad message to every candidate peers.  So that SPV can synchronize blocks with every peers no only the sync peer. 